### PR TITLE
Set required consent for content elements inside TYPO3 backend

### DIFF
--- a/Classes/Hooks/ContentObject/StdWrapHook.php
+++ b/Classes/Hooks/ContentObject/StdWrapHook.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tollwerk\TwEprivacy\Hooks\ContentObject;
+
+use Tollwerk\TwEprivacy\Utilities\EprivacyShield;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectStdWrapHookInterface;
+use Exception;
+
+/**
+ * StdWrapHook
+ *
+ * @package    Tollwerk\TwEprivacy
+ * @subpackage Tollwerk\TwEprivacy\Hooks\ContentObject
+ */
+class StdWrapHook implements ContentObjectStdWrapHookInterface
+{
+    /**
+     * Hook for modifying $content before core's stdWrap does anything
+     *
+     * @param string                $content       Input value undergoing processing in this function. Possibly
+     *                                             substituted by other values fetched from another source.
+     * @param array                 $configuration TypoScript stdWrap properties
+     * @param ContentObjectRenderer $parentObject  Parent content object
+     *
+     * @return string Further processed $content
+     * @throws Exception
+     */
+    public function stdWrapPreProcess($content, array $configuration, ContentObjectRenderer &$parentObject): string
+    {
+        // Check if cookie consent for one or more cookies is required. Do not render element if consent is missing.
+        if ($parentObject->getCurrentTable() == 'tt_content' && !empty($parentObject->data['tx_tweprivacy_consent'])) {
+            // Get required consent names from record
+            $consentItems = array_filter(GeneralUtility::trimExplode(',',
+                $parentObject->data['tx_tweprivacy_consent']));
+            if (!count($consentItems)) {
+                return $content;
+            }
+
+            // Check if all items are allowed. Return empty string on the first missing consent.
+            $eprivacyShield = GeneralUtility::makeInstance(EprivacyShield::class);
+            foreach ($consentItems as $consentItem) {
+                if (!$eprivacyShield->isAllowedName($consentItem)) {
+                    return '';
+                }
+            }
+        }
+
+        return $content;
+    }
+
+    /**
+     * Hook for modifying $content after core's stdWrap has processed setContentToCurrent, setCurrent, lang, data,
+     * field, current, cObject, numRows, filelist and/or preUserFunc
+     *
+     * @param string                $content       Input value undergoing processing in this function. Possibly
+     *                                             substituted by other values fetched from another source.
+     * @param array                 $configuration TypoScript stdWrap properties
+     * @param ContentObjectRenderer $parentObject  Parent content object
+     *
+     * @return string Further processed $content
+     */
+    public function stdWrapOverride($content, array $configuration, ContentObjectRenderer &$parentObject): string
+    {
+        return $content;
+    }
+
+    /**
+     * Hook for modifying $content after core's stdWrap has processed override, preIfEmptyListNum, ifEmpty, ifBlank,
+     * listNum, trim and/or more (nested) stdWraps
+     *
+     * @param string                $content       Input value undergoing processing in this function. Possibly
+     *                                             substituted by other values fetched from another source.
+     * @param array                 $configuration TypoScript "stdWrap properties".
+     * @param ContentObjectRenderer $parentObject  Parent content object
+     *
+     * @return string Further processed $content
+     */
+    public function stdWrapProcess($content, array $configuration, ContentObjectRenderer &$parentObject): string
+    {
+        return $content;
+    }
+
+    /**
+     * Hook for modifying $content after core's stdWrap has processed anything but debug
+     *
+     * @param string                $content       Input value undergoing processing in this function. Possibly
+     *                                             substituted by other values fetched from another source.
+     * @param array                 $configuration TypoScript stdWrap properties
+     * @param ContentObjectRenderer $parentObject  Parent content object
+     *
+     * @return string Further processed $content
+     */
+    public function stdWrapPostProcess($content, array $configuration, ContentObjectRenderer &$parentObject): string
+    {
+        return $content;
+    }
+}

--- a/Classes/Utilities/TcaUtility.php
+++ b/Classes/Utilities/TcaUtility.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * TcaUtility
+ *
+ * @subpackage ${NAMESPACE}
+ * @author     2022 Klaus Fiedler <klaus@tollwerk.de>
+ * @copyright  Copyright © 2022 2022 Klaus Fiedler <klaus@tollwerk.de>
+ * @license    http://opensource.org/licenses/MIT The MIT License (MIT)
+ */
+
+/***********************************************************************************
+ *  The MIT License (MIT)
+ *
+ *  Copyright © 2022 Klaus Fiedler <klaus@tollwerk.de>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy of
+ *  this software and associated documentation files (the "Software"), to deal in
+ *  the Software without restriction, including without limitation the rights to
+ *  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ *  the Software, and to permit persons to whom the Software is furnished to do so,
+ *  subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ *  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ *  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ *  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ***********************************************************************************/
+
+namespace Tollwerk\TwEprivacy\Utilities;
+
+use Doctrine\DBAL\Driver\Exception;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use UnexpectedValueException;
+
+/**
+ * TcaUtility
+ *
+ * @package    Tollwerk\TwEprivacy
+ * @subpackage Tollwerk\TwEprivacy\Utilities
+ */
+class TcaUtility
+{
+    /**
+     * Returns a list of tx_tweprivacy_domain_model_subject items for populating field "tx_tweprivacy_consent"
+     * in tt_content table (called as itemsProcFunc).
+     *
+     * @param array $configuration Current field configuration
+     *
+     * @throws UnexpectedValueException
+     * @throws Exception
+     * @internal
+     */
+    public function getConsentItems(array &$configuration)
+    {
+        // Get all tx_tweprivacy_domain_model_subject records
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+                                      ->getQueryBuilderForTable('tx_tweprivacy_domain_model_subject');
+        $records      = $queryBuilder
+            ->select('uid', 'title', 'name', 'identifier')
+            ->from('tx_tweprivacy_domain_model_subject')
+            ->where($queryBuilder->expr()->in('sys_language_uid', [-1, 0]))
+            ->execute()
+            ->fetchAllAssociative();
+
+        // Set items
+        foreach ($records as $record) {
+            $configuration['items'][] = [
+                sprintf('%s [%s]',
+                    $record['title'],
+                    $record['name'],
+                ),
+                $record['name']
+            ];
+        }
+    }
+}

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -21,6 +21,3 @@ $newColumns = [
 ];
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tt_content', $newColumns);
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tt_content', 'tx_tweprivacy_consent', '', 'after:hidden');
-
-// Add custom enablecolumns
-$GLOBALS['TCA']['tt_content']['ctrl']['enablecolumns']['cookie_consent'] = 'tx_tweprivacy_consent';

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,0 +1,26 @@
+<?php
+
+if (!defined('TYPO3_MODE')) {
+    die('Access denied.');
+}
+
+// Add new fields
+$newColumns = [
+    'tx_tweprivacy_consent' => [
+        'l10n_mode' => 'exclude',
+        'exclude' => true,
+        'label' => 'LLL:EXT:tw_eprivacy/Resources/Private/Language/locallang_db.xlf:tt_content.tx_tweprivacy_consent',
+        'config' => [
+            'exclude' => true,
+            'type' => 'select',
+            'renderType' => 'selectMultipleSideBySide',
+            'enableMultiSelectFilterTextfield' => true,
+            'itemsProcFunc' => \Tollwerk\TwEprivacy\Utilities\TcaUtility::class . '->getConsentItems'
+        ],
+    ],
+];
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tt_content', $newColumns);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tt_content', 'tx_tweprivacy_consent', '', 'after:hidden');
+
+// Add custom enablecolumns
+$GLOBALS['TCA']['tt_content']['ctrl']['enablecolumns']['cookie_consent'] = 'tx_tweprivacy_consent';

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # tollwerk ePrivacy Consent Manager
 
+## For editors
+
+Editors can set the required consent for content elements individually inside the TYPO3 backend.
+The field "Needs cookie consent" can be found on inside the "access"-tab of each content element.
+
 ## Fluid ViewHelper
 
 The `<eprivacy:consent>` viewhelper is a specialized condition viewhelper that enables you to test for the user's consent with particular subject identifiers. Examples:

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -61,6 +61,10 @@
                 <source>ePrivacy Consent Manager</source> <target state="translated">ePrivacy Einstellungsmananger</target></trans-unit>
             <trans-unit id="tx_tw_eprivacy_eprivacy.description" approved="yes">
                 <source>Form listing registered ePrivacy subjects including a way to give or withdraw consent to each of them.</source> <target state="translated">Formular mit einer Auflistung registrierter ePrivacy Einstellungen inklusive der Möglichkeit, zu jeder die Zustimmung geben oder entziehen zu können.</target></trans-unit>
+            <trans-unit id="tt_content.tx_tweprivacy_consent" approved="yes">
+                <source>Needs cookie consent</source>
+                <target>Benötigt Cookie-Consent</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/en.locallang_db.xlf
+++ b/Resources/Private/Language/en.locallang_db.xlf
@@ -91,6 +91,10 @@
                     them.
                 </source>
             <target state="translated">Form listing registered ePrivacy subjects including a way to give or withdraw consent to each of them.</target></trans-unit>
+            <trans-unit id="tt_content.tx_tweprivacy_consent" approved="yes">
+                <source>Needs cookie consent</source>
+                <target>Needs cookie consent</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/es.locallang_db.xlf
+++ b/Resources/Private/Language/es.locallang_db.xlf
@@ -61,6 +61,10 @@
                 <source>ePrivacy Consent Manager</source> <target state="translated">Administrador de consentimiento ePrivacy</target></trans-unit>
             <trans-unit id="tx_tw_eprivacy_eprivacy.description" approved="yes">
                 <source>Form listing registered ePrivacy subjects including a way to give or withdraw consent to each of them.</source> <target state="translated">Formulario registrado de asuntos ePrivacy incluida una forma para dar o retirar el consentimiento a cada uno de ellos.</target></trans-unit>
+            <trans-unit id="tt_content.tx_tweprivacy_consent" approved="yes">
+                <source>Needs cookie consent</source>
+                <target>Requiere el consentimiento de cookies</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/fr.locallang_db.xlf
+++ b/Resources/Private/Language/fr.locallang_db.xlf
@@ -74,6 +74,10 @@
             <trans-unit id="tx_tw_eprivacy_eprivacy.description" approved="yes">
                 <source>Form listing registered ePrivacy subjects including a way to give or withdraw consent to each of them.</source> <target state="translated">Formulaire avec liste des sujets ePrivacy enregistrés, incluant un moyen de donner ou de retirer son consentement pour chacun d'eux
 </target></trans-unit>
+            <trans-unit id="tt_content.tx_tweprivacy_consent" approved="yes">
+                <source>Needs cookie consent</source>
+                <target>Nécessite le consentement des cookies</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/it.locallang_db.xlf
+++ b/Resources/Private/Language/it.locallang_db.xlf
@@ -89,6 +89,10 @@
             <trans-unit id="tx_tw_eprivacy_eprivacy.description" approved="yes">
                 <source>Form listing registered ePrivacy subjects including a way to give or withdraw consent to each of them.</source> <target state="translated">Modulo che elenca i soggetti ePrivacy registrati, incluso un modo per dare o ritirare il consenso a ciascuno di essi.
 </target></trans-unit>
+            <trans-unit id="tt_content.tx_tweprivacy_consent" approved="yes">
+                <source>Needs cookie consent</source>
+                <target>Richiede il consenso ai cookie</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -93,6 +93,9 @@
                     them.
                 </source>
             </trans-unit>
+            <trans-unit id="tt_content.tx_tweprivacy_consent">
+                <source>Needs cookie consent</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -45,5 +45,8 @@ call_user_func(
 
         // Register Fluid namespace
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['eprivacy'] = ['Tollwerk\\TwEprivacy\\ViewHelpers'];
+
+        // Add Hooks
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['stdWrap'][] = \Tollwerk\TwEprivacy\Hooks\ContentObject\StdWrapHook::class;
     }
 );

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -5,7 +5,7 @@ CREATE TABLE tx_tweprivacy_domain_model_type
 (
     title         varchar(255)        DEFAULT '' NOT NULL,
     description   text,
-    needs_consent tinyint(4) unsigned DEFAULT '0',
+    needs_consent tinyint(4) unsigned DEFAULT '0'
 );
 
 #
@@ -15,7 +15,7 @@ CREATE TABLE tx_tweprivacy_domain_model_subject
 (
     title      varchar(255)         DEFAULT '' NOT NULL,
     name       varchar(255)         DEFAULT '' NOT NULL,
-    identifier varchar(64)         DEFAULT '' NOT NULL,
+    identifier varchar(64)          DEFAULT '' NOT NULL,
     provider   varchar(255)         DEFAULT '' NOT NULL,
     purpose    text,
     type       int(11) unsigned     DEFAULT '1',
@@ -25,5 +25,14 @@ CREATE TABLE tx_tweprivacy_domain_model_subject
     public     tinyint(4) unsigned  DEFAULT '1',
     session    tinyint(4) unsigned  DEFAULT '0',
 
-    UNIQUE idlang (identifier, sys_language_uid),
+    UNIQUE idlang (identifier, sys_language_uid)
+);
+
+
+#
+# Table structure for table 'tt_content'
+#
+CREATE TABLE tt_content
+(
+    tx_tweprivacy_consent varchar(255) DEFAULT '' NOT NULL,
 );


### PR DESCRIPTION
Editors can set the required consent for content elements individually inside the TYPO3 backend. The field "Needs cookie consent" can be found on inside the "access"-tab of each content element.