### PR TITLE
Show "Needs consent" message for hidden contents.

### DIFF
--- a/Classes/Controller/SubjectController.php
+++ b/Classes/Controller/SubjectController.php
@@ -19,11 +19,9 @@ use Tollwerk\TwEprivacy\Domain\Repository\ConsentRepository;
 use Tollwerk\TwEprivacy\Domain\Repository\SubjectRepository;
 use Tollwerk\TwEprivacy\Utilities\EprivacyShield;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\HttpUtility;
 use TYPO3\CMS\Extbase\Configuration\Exception\InvalidConfigurationTypeException;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Object\Exception;
-use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 
 /**
  * SubjectController
@@ -94,13 +92,6 @@ class SubjectController extends ActionController
 
         // Now add the new identifiers the users wants to allow.
         $subjects = array_merge($allSubjects, $addIdentifiers);
-
-        DebuggerUtility::var_dump([
-            'addIdentifiers' => $addIdentifiers,
-            'allSubjects' => $allSubjects,
-            'subjects' => $subjects,
-        ], __CLASS__);
-
         $consent = $this->consentRepository->get();
         $consent->setSubjects($subjects);
         $this->consentRepository->update($consent);

--- a/Classes/Hooks/ContentObject/StdWrapHook.php
+++ b/Classes/Hooks/ContentObject/StdWrapHook.php
@@ -1,11 +1,44 @@
 <?php
 
+/**
+ * ePrivacy
+ *
+ * @category   Tollwerk
+ * @package    Tollwerk\TwEprivacy
+ * @subpackage Tollwerk\TwEprivacy\Hooks\ContentObject
+ * @author     Klaus Fiedler <klaus@tollwerk.de>
+ * @copyright  Copyright © 2020 Joschi Kuphal <joschi@tollwerk.de> / @jkphl
+ * @license    http://opensource.org/licenses/MIT The MIT License (MIT)
+ */
+
+/***********************************************************************************
+ *  The MIT License (MIT)
+ *
+ *  Copyright © 2022 Joschi Kuphal <joschi@tollwerk.de> / @jkph
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy of
+ *  this software and associated documentation files (the "Software"), to deal in
+ *  the Software without restriction, including without limitation the rights to
+ *  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ *  the Software, and to permit persons to whom the Software is furnished to do so,
+ *  subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ *  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ *  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ *  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ***********************************************************************************/
+
 namespace Tollwerk\TwEprivacy\Hooks\ContentObject;
 
 use Tollwerk\TwEprivacy\Utilities\EprivacyShield;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
-use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 use TYPO3\CMS\Fluid\View\StandaloneView;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectStdWrapHookInterface;

--- a/Classes/Hooks/ContentObject/StdWrapHook.php
+++ b/Classes/Hooks/ContentObject/StdWrapHook.php
@@ -4,6 +4,7 @@ namespace Tollwerk\TwEprivacy\Hooks\ContentObject;
 
 use Tollwerk\TwEprivacy\Utilities\EprivacyShield;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\View\StandaloneView;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectStdWrapHookInterface;
 use Exception;
@@ -24,10 +25,57 @@ class StdWrapHook implements ContentObjectStdWrapHookInterface
      * @param array                 $configuration TypoScript stdWrap properties
      * @param ContentObjectRenderer $parentObject  Parent content object
      *
-     * @return string Further processed $content
+     * @return string|null Further processed $content
      * @throws Exception
      */
-    public function stdWrapPreProcess($content, array $configuration, ContentObjectRenderer &$parentObject): string
+    public function stdWrapPreProcess($content, array $configuration, ContentObjectRenderer &$parentObject): ?string
+    {
+        return $content;
+    }
+
+    /**
+     * Hook for modifying $content after core's stdWrap has processed setContentToCurrent, setCurrent, lang, data,
+     * field, current, cObject, numRows, filelist and/or preUserFunc
+     *
+     * @param string                $content       Input value undergoing processing in this function. Possibly
+     *                                             substituted by other values fetched from another source.
+     * @param array                 $configuration TypoScript stdWrap properties
+     * @param ContentObjectRenderer $parentObject  Parent content object
+     *
+     * @return string|null Further processed $content
+     */
+    public function stdWrapOverride($content, array $configuration, ContentObjectRenderer &$parentObject): ?string
+    {
+        return $content;
+    }
+
+    /**
+     * Hook for modifying $content after core's stdWrap has processed override, preIfEmptyListNum, ifEmpty, ifBlank,
+     * listNum, trim and/or more (nested) stdWraps
+     *
+     * @param string                $content       Input value undergoing processing in this function. Possibly
+     *                                             substituted by other values fetched from another source.
+     * @param array                 $configuration TypoScript "stdWrap properties".
+     * @param ContentObjectRenderer $parentObject  Parent content object
+     *
+     * @return string|null Further processed $content
+     */
+    public function stdWrapProcess($content, array $configuration, ContentObjectRenderer &$parentObject): ?string
+    {
+        return $content;
+    }
+
+    /**
+     * Hook for modifying $content after core's stdWrap has processed anything but debug
+     *
+     * @param string                $content       Input value undergoing processing in this function. Possibly
+     *                                             substituted by other values fetched from another source.
+     * @param array                 $configuration TypoScript stdWrap properties
+     * @param ContentObjectRenderer $parentObject  Parent content object
+     *
+     * @return string|null Further processed $content
+     */
+    public function stdWrapPostProcess($content, array $configuration, ContentObjectRenderer &$parentObject): ?string
     {
         // Check if cookie consent for one or more cookies is required. Do not render element if consent is missing.
         if ($parentObject->getCurrentTable() == 'tt_content' && !empty($parentObject->data['tx_tweprivacy_consent'])) {
@@ -42,58 +90,34 @@ class StdWrapHook implements ContentObjectStdWrapHookInterface
             $eprivacyShield = GeneralUtility::makeInstance(EprivacyShield::class);
             foreach ($consentItems as $consentItem) {
                 if (!$eprivacyShield->isAllowedName($consentItem)) {
+
+                    // TODO: Remove if()-statement after development.
+                    if($_SERVER['REMOTE_ADDR'] == '80.144.228.187') {
+
+                        /** @var StandaloneView $standaloneView */
+                        $standaloneView = GeneralUtility::makeInstance(StandaloneView::class);
+                        $standaloneView->setLayoutRootPaths([GeneralUtility::getFileAbsFileName('EXT:tw_eprivacy/Resources/Private/Layouts')]);
+                        $standaloneView->setPartialRootPaths([GeneralUtility::getFileAbsFileName('EXT:tw_eprivacy/Resources/Private/Partials')]);
+                        $standaloneView->setTemplateRootPaths([GeneralUtility::getFileAbsFileName('EXT:tw_eprivacy/Resources/Private/Templates')]);
+                        $standaloneView->getRequest()->setControllerExtensionName(GeneralUtility::underscoredToUpperCamelCase('tw_eprivacy'));
+                        $standaloneView->setTemplate('Content/NeedsConsent');
+                        $standaloneView->assign('consentItems', $consentItems);
+                        $standaloneView->assignMultiple([
+                            'consentItems' => $consentItems,
+                            'header' => $parentObject->data['header'],
+                            'uid' => $parentObject->data['uid'],
+                        ]);
+
+                        return $standaloneView->render();
+                    }
+
                     return '';
+
                 }
             }
         }
 
-        return $content;
-    }
 
-    /**
-     * Hook for modifying $content after core's stdWrap has processed setContentToCurrent, setCurrent, lang, data,
-     * field, current, cObject, numRows, filelist and/or preUserFunc
-     *
-     * @param string                $content       Input value undergoing processing in this function. Possibly
-     *                                             substituted by other values fetched from another source.
-     * @param array                 $configuration TypoScript stdWrap properties
-     * @param ContentObjectRenderer $parentObject  Parent content object
-     *
-     * @return string Further processed $content
-     */
-    public function stdWrapOverride($content, array $configuration, ContentObjectRenderer &$parentObject): string
-    {
-        return $content;
-    }
-
-    /**
-     * Hook for modifying $content after core's stdWrap has processed override, preIfEmptyListNum, ifEmpty, ifBlank,
-     * listNum, trim and/or more (nested) stdWraps
-     *
-     * @param string                $content       Input value undergoing processing in this function. Possibly
-     *                                             substituted by other values fetched from another source.
-     * @param array                 $configuration TypoScript "stdWrap properties".
-     * @param ContentObjectRenderer $parentObject  Parent content object
-     *
-     * @return string Further processed $content
-     */
-    public function stdWrapProcess($content, array $configuration, ContentObjectRenderer &$parentObject): string
-    {
-        return $content;
-    }
-
-    /**
-     * Hook for modifying $content after core's stdWrap has processed anything but debug
-     *
-     * @param string                $content       Input value undergoing processing in this function. Possibly
-     *                                             substituted by other values fetched from another source.
-     * @param array                 $configuration TypoScript stdWrap properties
-     * @param ContentObjectRenderer $parentObject  Parent content object
-     *
-     * @return string Further processed $content
-     */
-    public function stdWrapPostProcess($content, array $configuration, ContentObjectRenderer &$parentObject): string
-    {
         return $content;
     }
 }

--- a/Classes/Hooks/ContentObject/StdWrapHook.php
+++ b/Classes/Hooks/ContentObject/StdWrapHook.php
@@ -4,6 +4,8 @@ namespace Tollwerk\TwEprivacy\Hooks\ContentObject;
 
 use Tollwerk\TwEprivacy\Utilities\EprivacyShield;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
+use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 use TYPO3\CMS\Fluid\View\StandaloneView;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectStdWrapHookInterface;
@@ -94,6 +96,10 @@ class StdWrapHook implements ContentObjectStdWrapHookInterface
                     // TODO: Remove if()-statement after development.
                     if($_SERVER['REMOTE_ADDR'] == '80.144.228.187') {
 
+                        $configurationManager = GeneralUtility::makeInstance(ConfigurationManager::class);
+                        $typoscript = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
+                        $settings = $typoscript['plugin.']['tx_tweprivacy_eprivacy.']['settings.'];
+
                         /** @var StandaloneView $standaloneView */
                         $standaloneView = GeneralUtility::makeInstance(StandaloneView::class);
                         $standaloneView->setLayoutRootPaths([GeneralUtility::getFileAbsFileName('EXT:tw_eprivacy/Resources/Private/Layouts')]);
@@ -104,8 +110,8 @@ class StdWrapHook implements ContentObjectStdWrapHookInterface
                         $standaloneView->assign('consentItems', $consentItems);
                         $standaloneView->assignMultiple([
                             'consentItems' => $consentItems,
-                            'header' => $parentObject->data['header'],
-                            'uid' => $parentObject->data['uid'],
+                            'data' => $parentObject->data,
+                            'settings' => $settings,
                         ]);
 
                         return $standaloneView->render();

--- a/Classes/ViewHelpers/FindSubjectsByNameViewHelper.php
+++ b/Classes/ViewHelpers/FindSubjectsByNameViewHelper.php
@@ -36,13 +36,9 @@
 
 namespace Tollwerk\TwEprivacy\ViewHelpers;
 
-use Tollwerk\TwEprivacy\Utilities\EprivacyShield;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\Exception;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
-use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 

--- a/Classes/ViewHelpers/FindSubjectsByNameViewHelper.php
+++ b/Classes/ViewHelpers/FindSubjectsByNameViewHelper.php
@@ -6,7 +6,7 @@
  * @category   Tollwerk
  * @package    Tollwerk\TwEprivacy
  * @subpackage Tollwerk\TwEprivacy\ViewHelpers
- * @author     Joschi Kuphal <joschi@tollwerk.de> / @jkphl
+ * @author     Klaus Fiedler <klaus@tollwerk.de>
  * @copyright  Copyright © 2020 Joschi Kuphal <joschi@tollwerk.de> / @jkphl
  * @license    http://opensource.org/licenses/MIT The MIT License (MIT)
  */
@@ -14,7 +14,7 @@
 /***********************************************************************************
  *  The MIT License (MIT)
  *
- *  Copyright © 2020 Joschi Kuphal <joschi@tollwerk.de>
+ * Copyright © 2020 Joschi Kuphal <joschi@tollwerk.de> / @jkphl
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy of
  *  this software and associated documentation files (the "Software"), to deal in

--- a/Classes/ViewHelpers/FindSubjectsByNameViewHelper.php
+++ b/Classes/ViewHelpers/FindSubjectsByNameViewHelper.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * ePrivacy
+ *
+ * @category   Tollwerk
+ * @package    Tollwerk\TwEprivacy
+ * @subpackage Tollwerk\TwEprivacy\ViewHelpers
+ * @author     Joschi Kuphal <joschi@tollwerk.de> / @jkphl
+ * @copyright  Copyright © 2020 Joschi Kuphal <joschi@tollwerk.de> / @jkphl
+ * @license    http://opensource.org/licenses/MIT The MIT License (MIT)
+ */
+
+/***********************************************************************************
+ *  The MIT License (MIT)
+ *
+ *  Copyright © 2020 Joschi Kuphal <joschi@tollwerk.de>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy of
+ *  this software and associated documentation files (the "Software"), to deal in
+ *  the Software without restriction, including without limitation the rights to
+ *  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ *  the Software, and to permit persons to whom the Software is furnished to do so,
+ *  subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ *  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ *  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ *  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ***********************************************************************************/
+
+namespace Tollwerk\TwEprivacy\ViewHelpers;
+
+use Tollwerk\TwEprivacy\Utilities\EprivacyShield;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\Exception;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+/**
+ * FindSubjectsByNameViewHelper
+ *
+ * Find subjects by their name and return them with their identifier as key.
+ *
+ * @package    Tollwerk\TwEprivacy
+ * @subpackage Tollwerk\TwEprivacy\ViewHelpers
+ */
+class FindSubjectsByNameViewHelper extends AbstractViewHelper
+{
+    /**
+     * Initialize all arguments. You need to override this method and call
+     * $this->registerArgument(...) inside this method, to register all your arguments.
+     *
+     * @return void
+     * @api
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('names', 'array', 'Subject names', false, []);
+    }
+
+    /**
+     * Default implementation of static rendering; useful API method if your ViewHelper
+     * when compiled is able to render itself statically to increase performance. This
+     * default implementation will simply delegate to the ViewHelperInvoker.
+     *
+     * @param array                     $arguments
+     * @param \Closure                  $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     *
+     * @return mixed
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
+
+        // Get current frontend language for query
+        $context = GeneralUtility::makeInstance(Context::class);
+        $sysLanguageUid = $context->getPropertyFromAspect('language', 'id');
+
+        // Prepare $subjects for query
+        $subjects = $arguments['names'];
+        array_walk($subjects, function(&$value){ $value = '"' . $value . '"';});
+
+        // Create query
+        $query = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_tweprivacy_domain_model_subject');
+        $subjects = $query->select('uid', 'name', 'title', 'identifier', 'purpose')
+                              ->from('tx_tweprivacy_domain_model_subject')
+                              ->where($query->expr()->eq('sys_language_uid', $sysLanguageUid))
+                              ->andWhere($query->expr()->in('name', $subjects))
+                              ->execute()
+                              ->fetchAllAssociative();
+
+        $subjectsByIdentifier = [
+            'byIdentifier' => [],
+            'identifiers' => [],
+        ];
+        foreach($subjects as $subject) {
+            $subjectsByIdentifier['identifiers'][] = $subject['identifier'];
+            $subjectsByIdentifier['byIdentifier'][$subject['identifier']] = $subject;
+        }
+
+        return $subjectsByIdentifier;
+    }
+}

--- a/Configuration/TypoScript/Static/constants.typoscript
+++ b/Configuration/TypoScript/Static/constants.typoscript
@@ -31,5 +31,7 @@ plugin.tx_tweprivacy_eprivacy {
         imprint =
         # cat=plugin.tx_tweprivacy_eprivacy/common/c; type=int+; label=LLL:EXT:tw_eprivacy/Resources/Private/Language/locallang_db.xlf:common.privacy
         privacy =
+        # cat=plugin.tx_tweprivacy_eprivacy/common/c; type=int+; label=LLL:EXT:tw_eprivacy/Resources/Private/Language/locallang_db.xlf:common.pluginPid
+        pluginPid =
     }
 }

--- a/Configuration/TypoScript/Static/setup.typoscript
+++ b/Configuration/TypoScript/Static/setup.typoscript
@@ -21,6 +21,7 @@ plugin.tx_tweprivacy_eprivacy {
         httponly = {$plugin.tx_tweprivacy_eprivacy.settings.httponly}
         imprint = {$plugin.tx_tweprivacy_eprivacy.settings.imprint}
         privacy = {$plugin.tx_tweprivacy_eprivacy.settings.privacy}
+        pluginPid = {$plugin.tx_tweprivacy_eprivacy.settings.pluginPid}
     }
 
     features {

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -23,7 +23,11 @@
 				<source>Reset</source> <target state="translated">Zurücksetzen</target></trans-unit>
 			<trans-unit id="content.needsConsent.text">
 				<source>A content was hidden because you did not agree to all necessary cookies. In order to see the content, you must agree to the following cookies.</source>
-				<target>Der Inhalt "%s" wurde ausgeblendet, weil Sie nicht allen notwendigen Cookies zugestimmt haben. Um den Inhalt zu sehen, müssen Sie den folgenden Cookies zustimmen.</target>
+				<target>Der Inhalt "%s" wurde ausgeblendet, weil Sie nicht allen notwendigen Cookies zugestimmt haben. Um den Inhalt zu sehen zu können, müssen folgenden Cookies zugelassen werden.</target>
+			</trans-unit>
+			<trans-unit id="content.needsConsent.actions">
+				<source>Click <![CDATA[<a href="%s">here</a>]]> to show the content, accepting all required cookies. You can manage all of your settings on <![CDATA[<a href="%s">this page</a>]]>.</source>
+				<target>Klicken Sie <![CDATA[<a href="%s">hier</a>]]>, um den Inhalt anzuzeigen und alle notwendigen Cookies zu akzeptieren. Auf <![CDATA[<a href="%s">dieser Seite</a>]]> können sämtliche Cookie-Einstellungen verwaltet werden.</target>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -23,7 +23,7 @@
 				<source>Reset</source> <target state="translated">Zurücksetzen</target></trans-unit>
 			<trans-unit id="content.needsConsent.text">
 				<source>A content was hidden because you did not agree to all necessary cookies. In order to see the content, you must agree to the following cookies.</source>
-				<target>Der Inhalt "%s" wurde ausgeblendet, weil Sie nicht allen notwendigen Cookies zugestimmt haben. Um den Inhalt zu sehen zu können, müssen folgenden Cookies zugelassen werden.</target>
+				<target>Der Inhalt "%s" wurde ausgeblendet, weil Sie nicht allen notwendigen Cookies zugestimmt haben. Um den Inhalt sehen zu können, müssen folgenden Cookies zugelassen werden.</target>
 			</trans-unit>
 			<trans-unit id="content.needsConsent.actions">
 				<source>Click <![CDATA[<a href="%s">here</a>]]> to show the content, accepting all required cookies. You can manage all of your settings on <![CDATA[<a href="%s">this page</a>]]>.</source>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -21,6 +21,10 @@
 				<source>Accept necessary only</source> <target state="translated">Notwendige akzeptieren</target></trans-unit>
 			<trans-unit id="eprivacy.update.reset" approved="yes">
 				<source>Reset</source> <target state="translated">Zurücksetzen</target></trans-unit>
+			<trans-unit id="content.needsConsent.text">
+				<source>A content was hidden because you did not agree to all necessary cookies. In order to see the content, you must agree to the following cookies.</source>
+				<target>Der Inhalt "%s" wurde ausgeblendet, weil Sie nicht allen notwendigen Cookies zugestimmt haben. Um den Inhalt zu sehen, müssen Sie den folgenden Cookies zustimmen.</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -9,6 +9,10 @@
                 <source>Imprint Page (ID)</source> <target state="translated">Impressumsseite (ID)</target></trans-unit>
             <trans-unit id="common.privacy" approved="yes">
                 <source>Privacy Policy Page (ID)</source> <target state="translated">Datenschutzerklärung (ID)</target></trans-unit>
+            <trans-unit id="common.pluginPid">
+                <source>Plugin Page (ID)</source>
+                <target>Seite mit Plugin (ID)</target>
+            </trans-unit>
             <trans-unit id="cookie" approved="yes">
                 <source>Consent Cookie</source> <target state="translated">Cookie-Zustimmung</target></trans-unit>
             <trans-unit id="cookie.lifetime" approved="yes">

--- a/Resources/Private/Language/en.locallang.xlf
+++ b/Resources/Private/Language/en.locallang.xlf
@@ -25,6 +25,10 @@
 				<source>A content was hidden because you did not agree to all necessary cookies. In order to see the content, you must agree to the following cookies.</source>
 				<target>The content "%s" was hidden because you did not agree to all necessary cookies. In order to see the content, you must agree to the following cookies.</target>
 			</trans-unit>
+			<trans-unit id="content.needsConsent.actions">
+				<source>Click <![CDATA[<a href="%s">here</a>]]> to show the content, accepting all required cookies. You can manage all of your settings on <![CDATA[<a href="%s">this page</a>]]>.</source>
+				<target>Click <![CDATA[<a href="%s">here</a>]]> to show the content, accepting all required cookies. You can manage all of your settings on <![CDATA[<a href="%s">this page</a>]]>.</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/en.locallang.xlf
+++ b/Resources/Private/Language/en.locallang.xlf
@@ -21,6 +21,10 @@
 				<source>Accept necessary only</source> <target state="translated">Accept necessary only</target></trans-unit>
 			<trans-unit id="eprivacy.update.reset" approved="yes">
 				<source>Reset</source> <target state="translated">Reset</target></trans-unit>
+			<trans-unit id="content.needsConsent.text">
+				<source>A content was hidden because you did not agree to all necessary cookies. In order to see the content, you must agree to the following cookies.</source>
+				<target>The content "%s" was hidden because you did not agree to all necessary cookies. In order to see the content, you must agree to the following cookies.</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/en.locallang_db.xlf
+++ b/Resources/Private/Language/en.locallang_db.xlf
@@ -11,6 +11,10 @@
             <trans-unit id="common.privacy" approved="yes">
                 <source>Privacy Policy Page (ID)</source>
             <target state="translated">Privacy Policy Page (ID)</target></trans-unit>
+            <trans-unit id="common.pluginPid">
+                <source>Plugin Page (ID)</source>
+                <target>Plugin Page (ID)</target>
+            </trans-unit>
             <trans-unit id="cookie" approved="yes">
                 <source>Consent Cookie</source>
             <target state="translated">Consent Cookie</target></trans-unit>

--- a/Resources/Private/Language/es.locallang.xlf
+++ b/Resources/Private/Language/es.locallang.xlf
@@ -21,6 +21,10 @@
 				<source>Accept necessary only</source> <target state="translated">Aceptar solo las necesarias</target></trans-unit>
 			<trans-unit id="eprivacy.update.reset" approved="yes">
 				<source>Reset</source> <target state="translated">Restablecer</target></trans-unit>
+			<trans-unit id="content.needsConsent.text">
+				<source>A content was hidden because you did not agree to all necessary cookies. In order to see the content, you must agree to the following cookies.</source>
+				<target>Se ocultó el contenido porque no aceptaste todas las cookies necesarias. Para ver el contenido, debe aceptar las siguientes cookies.</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/es.locallang.xlf
+++ b/Resources/Private/Language/es.locallang.xlf
@@ -25,6 +25,10 @@
 				<source>A content was hidden because you did not agree to all necessary cookies. In order to see the content, you must agree to the following cookies.</source>
 				<target>Se ocultó el contenido porque no aceptaste todas las cookies necesarias. Para ver el contenido, debe aceptar las siguientes cookies.</target>
 			</trans-unit>
+			<trans-unit id="content.needsConsent.actions">
+				<source>Click <![CDATA[<a href="%s">here</a>]]> to show the content, accepting all required cookies. You can manage all of your settings on <![CDATA[<a href="%s">this page</a>]]>.</source>
+				<target>Haga clic <![CDATA[<a href="%s">aquí</a>]]> para mostrar el contenido, aceptando todas las cookies requeridas. Puede administrar todas sus configuraciones en <![CDATA[<a href="%s">esta página</a>]]>.</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/es.locallang_db.xlf
+++ b/Resources/Private/Language/es.locallang_db.xlf
@@ -9,6 +9,10 @@
                 <source>Imprint Page (ID)</source> <target state="translated">Página Impresión (ID)</target></trans-unit>
             <trans-unit id="common.privacy" approved="yes">
                 <source>Privacy Policy Page (ID)</source> <target state="translated">Página Política de Privacidad (ID)</target></trans-unit>
+            <trans-unit id="common.pluginPid">
+                <source>Plugin Page (ID)</source>
+                <target>Página con complemento (ID)</target>
+            </trans-unit>
             <trans-unit id="cookie" approved="yes">
                 <source>Consent Cookie</source> <target state="translated">Cookie de consentimiento</target></trans-unit>
             <trans-unit id="cookie.lifetime" approved="yes">

--- a/Resources/Private/Language/fr.locallang.xlf
+++ b/Resources/Private/Language/fr.locallang.xlf
@@ -21,6 +21,10 @@
 				<source>Accept necessary only</source> <target state="translated">N'accepter que les cookies nécessaires</target></trans-unit>
 			<trans-unit id="eprivacy.update.reset" approved="yes">
 				<source>Reset</source> <target state="translated">Réinitialiser</target></trans-unit>
+			<trans-unit id="content.needsConsent.text">
+				<source>A content was hidden because you did not agree to all necessary cookies. In order to see the content, you must agree to the following cookies.</source>
+				<target>Le contenu "%s" a été masqué car vous n'avez pas accepté tous les cookies nécessaires. Pour voir le contenu, vous devez accepter les cookies suivants.</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/fr.locallang.xlf
+++ b/Resources/Private/Language/fr.locallang.xlf
@@ -25,6 +25,10 @@
 				<source>A content was hidden because you did not agree to all necessary cookies. In order to see the content, you must agree to the following cookies.</source>
 				<target>Le contenu "%s" a été masqué car vous n'avez pas accepté tous les cookies nécessaires. Pour voir le contenu, vous devez accepter les cookies suivants.</target>
 			</trans-unit>
+			<trans-unit id="content.needsConsent.actions">
+				<source>Click <![CDATA[<a href="%s">here</a>]]> to show the content, accepting all required cookies. You can manage all of your settings on <![CDATA[<a href="%s">this page</a>]]>.</source>
+				<target>Cliquez <![CDATA[<a href="%s">ici</a>]]> pour afficher le contenu, en acceptant tous les cookies requis. Vous pouvez gérer tous vos paramètres sur <![CDATA[<a href="%s">cette page</a>]]>.</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/fr.locallang_db.xlf
+++ b/Resources/Private/Language/fr.locallang_db.xlf
@@ -9,6 +9,10 @@
                 <source>Imprint Page (ID)</source> <target state="translated">Page Mentions légales (ID)</target></trans-unit>
             <trans-unit id="common.privacy" approved="yes">
                 <source>Privacy Policy Page (ID)</source> <target state="translated">Page Politique de confidentialité (ID)</target></trans-unit>
+            <trans-unit id="common.pluginPid">
+                <source>Plugin Page (ID)</source>
+                <target>Page avec plugin (ID)</target>
+            </trans-unit>
             <trans-unit id="cookie" approved="yes">
                 <source>Consent Cookie</source> <target state="translated">Cookie de consentement</target></trans-unit>
             <trans-unit id="cookie.lifetime" approved="yes">

--- a/Resources/Private/Language/it.locallang.xlf
+++ b/Resources/Private/Language/it.locallang.xlf
@@ -25,6 +25,10 @@
 				<source>A content was hidden because you did not agree to all necessary cookies. In order to see the content, you must agree to the following cookies.</source>
 				<target>il contenuto "%s" è stato nascosto perché non hai acconsentito a tutti i cookie necessari. Per visualizzare il contenuto, devi accettare i seguenti cookie.</target>
 			</trans-unit>
+			<trans-unit id="content.needsConsent.actions">
+				<source>Click <![CDATA[<a href="%s">here</a>]]> to show the content, accepting all required cookies. You can manage all of your settings on <![CDATA[<a href="%s">this page</a>]]>.</source>
+				<target>Clicca <![CDATA[<a href="%s">qui</a>]]> per mostrare il contenuto, accettando tutti i cookie richiesti. Puoi gestire tutte le tue impostazioni su <![CDATA[<a href="%s">questa pagina</a>]]>.</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/it.locallang.xlf
+++ b/Resources/Private/Language/it.locallang.xlf
@@ -21,6 +21,10 @@
 				<source>Accept necessary only</source> <target state="translated">Accetta solo se necessario</target></trans-unit>
 			<trans-unit id="eprivacy.update.reset" approved="yes">
 				<source>Reset</source> <target state="translated">Reset</target></trans-unit>
+			<trans-unit id="content.needsConsent.text">
+				<source>A content was hidden because you did not agree to all necessary cookies. In order to see the content, you must agree to the following cookies.</source>
+				<target>il contenuto "%s" è stato nascosto perché non hai acconsentito a tutti i cookie necessari. Per visualizzare il contenuto, devi accettare i seguenti cookie.</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/it.locallang_db.xlf
+++ b/Resources/Private/Language/it.locallang_db.xlf
@@ -11,6 +11,10 @@
             <trans-unit id="common.privacy" approved="yes">
                 <source>Privacy Policy Page (ID)</source> <target state="translated">Pagina informativa sulla privacy (ID)
 </target></trans-unit>
+            <trans-unit id="common.pluginPid">
+                <source>Plugin Page (ID)</source>
+                <target>Pagina con plugin (ID)</target>
+            </trans-unit>
             <trans-unit id="cookie" approved="yes">
                 <source>Consent Cookie</source> <target state="translated">Cookie di consenso
 </target></trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -30,8 +30,11 @@
 			<trans-unit id="eprivacy.update.reset">
 				<source>Reset</source>
 			</trans-unit>
-			<trans-unit id="content.needsConsent.text">
+			<trans-unit id="content.needsConsent.description">
 				<source>The content "%s" was hidden because you did not agree to all necessary cookies. In order to see the content, you must agree to the following cookies.</source>
+			</trans-unit>
+			<trans-unit id="content.needsConsent.actions">
+				<source>Click <![CDATA[<a href="%s">here</a>]]> to show the content, accepting all required cookies. You can manage all of your settings on <![CDATA[<a href="%s">this page</a>]]>.</source>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -30,6 +30,9 @@
 			<trans-unit id="eprivacy.update.reset">
 				<source>Reset</source>
 			</trans-unit>
+			<trans-unit id="content.needsConsent.text">
+				<source>The content "%s" was hidden because you did not agree to all necessary cookies. In order to see the content, you must agree to the following cookies.</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -13,6 +13,9 @@
             <trans-unit id="common.privacy">
                 <source>Privacy Policy Page (ID)</source>
             </trans-unit>
+            <trans-unit id="common.pluginPid">
+                <source>Plugin Page (ID)</source>
+            </trans-unit>
             <trans-unit id="cookie">
                 <source>Consent Cookie</source>
             </trans-unit>

--- a/Resources/Private/Templates/Content/NeedsConsent.html
+++ b/Resources/Private/Templates/Content/NeedsConsent.html
@@ -1,9 +1,12 @@
 <f:comment><!--
 
-    Content needs consent message
+    Content needs consent message.
 
-    @param int      uid             UID of the content element
-    @param array[]  consentItems    Subject identifiers of required cookies for this content
+    Show all required cookies.
+    Show link to accept the required cookies and another link open to the cookie plugin page.
+
+    @param array  data            Content element data
+    @param array  consentItems    Subject identifiers of required cookies for this content
 
 --></f:comment>
 <html xmlns:f="https://xsd.helhum.io/ns/typo3/cms-fluid/master/ViewHelpers"
@@ -16,7 +19,7 @@
 
         <f:comment><!-- Description text --></f:comment>
         <p class="CookieNeedsConsent__text">
-            {f:translate(key: 'content.needsConsent.text', arguments: {0: header})}
+            {f:translate(key: 'content.needsConsent.text', arguments: {0: data.header})}
         </p>
 
         <f:comment><!-- List of required subjects --></f:comment>
@@ -34,21 +37,20 @@
         <f:comment><!-- Accept cookies --></f:comment>
         <f:variable name="acceptUrl"
                     value="{f:uri.action(
-                        pageUid: 473,
+                        pageUid: settings.pluginPid,
                         action: 'addConsent',
                         controller: 'Subject',
                         pluginName: 'Eprivacy',
                         extensionName: 'TwEprivacy',
-                        section: 'c{uid}',
-                        arguments: '{pid: 1, addIdentifiers: subjects.identifiers}'
+                        section: 'c{data.uid}',
+                        arguments: '{pid: data.pid, addIdentifiers: subjects.identifiers}'
                     )}"
         />
-        <f:variable name="pluginPageUrl" value="{f:uri.page(pageUid: 473)}" />
-        <f:debug>{acceptUrl}</f:debug>
-        <f:debug>{pluginPageUrl}</f:debug>
+        <f:variable name="pluginPageUrl" value="{f:uri.page(pageUid: settings.pluginPid)}"/>
         <p class="CookieNeedsConsent__actions">
-            <f:format.raw>{f:translate(key: 'content.needsConsent.actions', arguments: {0: acceptUrl, 1: pluginPageUrl})}</f:format.raw>
+            <f:format.raw>{f:translate(key: 'content.needsConsent.actions', arguments: {0: acceptUrl, 1:
+                pluginPageUrl})}
+            </f:format.raw>
         </p>
     </aside>
-
 </html>

--- a/Resources/Private/Templates/Content/NeedsConsent.html
+++ b/Resources/Private/Templates/Content/NeedsConsent.html
@@ -2,45 +2,52 @@
 
     Content needs consent message
 
-    @param array[] subjects			Subjects
-
+    @param int      uid             UID of the content element
+    @param array[]  consentItems    Subject identifiers of required cookies for this content
 
 --></f:comment>
 <html xmlns:f="https://xsd.helhum.io/ns/typo3/cms-fluid/master/ViewHelpers"
       xmlns:eprivacy="http://typo3.org/ns/Tollwerk/tw_eprivacy/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-    <f:variable name="subjects" value="{eprivacy:findSubjectsByName(names: consentItems)}"/>
-
     <aside class="CookieNeedsConsent">
+        <f:comment><!-- Get full subject records --></f:comment>
+        <f:variable name="subjects" value="{eprivacy:findSubjectsByName(names: consentItems)}"/>
+
+        <f:comment><!-- Description text --></f:comment>
         <p class="CookieNeedsConsent__text">
             {f:translate(key: 'content.needsConsent.text', arguments: {0: header})}
         </p>
-        <f:debug>{subjects}</f:debug>
 
+        <f:comment><!-- List of required subjects --></f:comment>
         <ul class="CookieNeedsConsent__subjects">
-            <f:for each="{subjects.byIdentifier}"as="subject">
+            <f:for each="{subjects.byIdentifier}" as="subject">
                 <li class="CookieNeedsConsent__subject">
                     <details>
                         <summary>{subject.title}</summary>
                         <f:format.html>{subject.purpose}</f:format.html>
                     </details>
-
                 </li>
             </f:for>
         </ul>
-        <p>
-            Klicken Sie
-            <f:link.action
-                    pageUid="473"
-                    action="addConsent"
-                    controller="Subject"
-                    pluginName="Eprivacy"
-                    extensionName="TwEprivacy"
-                    arguments="{pid: 1, addIdentifiers: subjects.identifiers}"
-                    section="c{uid}"
-            >hier</f:link.action>
-            , um diese Cookies zu akzeptieren. Alle Cookie-Einstellungen Sie finden sie <f:link.page pageUid="473">dieser Seite</f:link.page>.
+
+        <f:comment><!-- Accept cookies --></f:comment>
+        <f:variable name="acceptUrl"
+                    value="{f:uri.action(
+                        pageUid: 473,
+                        action: 'addConsent',
+                        controller: 'Subject',
+                        pluginName: 'Eprivacy',
+                        extensionName: 'TwEprivacy',
+                        section: 'c{uid}',
+                        arguments: '{pid: 1, addIdentifiers: subjects.identifiers}'
+                    )}"
+        />
+        <f:variable name="pluginPageUrl" value="{f:uri.page(pageUid: 473)}" />
+        <f:debug>{acceptUrl}</f:debug>
+        <f:debug>{pluginPageUrl}</f:debug>
+        <p class="CookieNeedsConsent__actions">
+            <f:format.raw>{f:translate(key: 'content.needsConsent.actions', arguments: {0: acceptUrl, 1: pluginPageUrl})}</f:format.raw>
         </p>
     </aside>
 

--- a/Resources/Private/Templates/Content/NeedsConsent.html
+++ b/Resources/Private/Templates/Content/NeedsConsent.html
@@ -1,0 +1,47 @@
+<f:comment><!--
+
+    Content needs consent message
+
+    @param array[] subjects			Subjects
+
+
+--></f:comment>
+<html xmlns:f="https://xsd.helhum.io/ns/typo3/cms-fluid/master/ViewHelpers"
+      xmlns:eprivacy="http://typo3.org/ns/Tollwerk/tw_eprivacy/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+
+    <f:variable name="subjects" value="{eprivacy:findSubjectsByName(names: consentItems)}"/>
+
+    <aside class="CookieNeedsConsent">
+        <p class="CookieNeedsConsent__text">
+            {f:translate(key: 'content.needsConsent.text', arguments: {0: header})}
+        </p>
+        <f:debug>{subjects}</f:debug>
+
+        <ul class="CookieNeedsConsent__subjects">
+            <f:for each="{subjects.byIdentifier}"as="subject">
+                <li class="CookieNeedsConsent__subject">
+                    <details>
+                        <summary>{subject.title}</summary>
+                        <f:format.html>{subject.purpose}</f:format.html>
+                    </details>
+
+                </li>
+            </f:for>
+        </ul>
+        <p>
+            Klicken Sie
+            <f:link.action
+                    pageUid="473"
+                    action="addConsent"
+                    controller="Subject"
+                    pluginName="Eprivacy"
+                    extensionName="TwEprivacy"
+                    arguments="{pid: 1, addIdentifiers: subjects.identifiers}"
+                    section="c{uid}"
+            >hier</f:link.action>
+            , um diese Cookies zu akzeptieren. Alle Cookie-Einstellungen Sie finden sie <f:link.page pageUid="473">dieser Seite</f:link.page>.
+        </p>
+    </aside>
+
+</html>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -8,11 +8,11 @@ call_user_func(
             'Tollwerk.TwEprivacy',
             'Eprivacy',
             [
-                'Subject' => 'list'
+                'Subject' => 'list, addConsent'
             ],
             // non-cacheable actions
             [
-                'Subject' => ''
+                'Subject' => 'addConsent'
             ]
         );
 


### PR DESCRIPTION
If a content element is hidden because of missing consent, a message is shown. This message includes:

* A short note that there is content hidden because of missing consent for one or more cookies. This note includes the content element's header.
* A list of all required cookies to show this content as `<details>` elements, so users can read the `subject.purpose` right there.
* A link for accepting those required cookies. The user will be redirected back to the current page and the missing content, which is visible then.
* A link to the general cookie plugin page.

**Example of "Needs consent" message:**
![Schnappschuss_012722_074738_AM](https://user-images.githubusercontent.com/8362710/151306333-0b37f4a5-ceed-4713-baa4-1cae963d94b8.jpg)
